### PR TITLE
Fix text overflow

### DIFF
--- a/src/styles/card.module.scss
+++ b/src/styles/card.module.scss
@@ -1,10 +1,8 @@
 @use 'sass:math';
 
 $width: 300px;
-$height: 265px;
 
 .card {
-  height: $height;
   width: $width;
   margin: 10px 5px;
   border-radius: 0;


### PR DESCRIPTION
Hiya @btalb,
This fixes the issue in https://qcr.github.io/dataset/ for the "RT-GENE: Real-Time Eye Gaze Estimation in Natural Environments Dataset". Currently the text does not fit in the specified box. Without explicitly setting the height, the container is adaptive. Looks nicer in general - rows where all text just has one line now occupy less space, rows where some text has two lines the same amount of space as now, and three lines and more are now properly displayed.